### PR TITLE
Deprecate .NET 7, Node.js 16 and Python 3.8 runtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ You can write functions in any of the following runtimes and execute them straig
 - Java 11
 - Java 8
 - .NET 8
-- .NET 7
 - .NET 6
 - Ruby 3.3
 - Ruby 3.2
@@ -42,7 +41,7 @@ You can write functions in any of the following runtimes and execute them straig
 
 Any runtime that [Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), you can use!
 
-Sidecar is maintained by [Aaron Francis](https://twitter.com/aarondfrancis), go follow me on Twitter! 
+Sidecar is maintained by [Aaron Francis](https://twitter.com/aarondfrancis), go follow me on Twitter!
 
 ### What It Looks Like
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ You can write functions in any of the following runtimes and execute them straig
 
 - Node.js 20
 - Node.js 18
-- Node.js 16
 - Python 3.12
 - Python 3.11
 - Python 3.10

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ You can write functions in any of the following runtimes and execute them straig
 - Python 3.11
 - Python 3.10
 - Python 3.9
-- Python 3.8
 - Java 21
 - Java 17
 - Java 11

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -13,7 +13,6 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 - Python 3.11: `python3.11`
 - Python 3.10: `python3.10`
 - Python 3.9: `python3.9`
-- Python 3.8: `python3.8`
 - Java 21: `java21`
 - Java 17: `java17`
 - Java 11: `java11`

--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -9,7 +9,6 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 
 - Node.js 20: `nodejs20.x`
 - Node.js 18: `nodejs18.x`
-- Node.js 16: `nodejs16.x`
 - Python 3.12: `python3.12`
 - Python 3.11: `python3.11`
 - Python 3.10: `python3.10`
@@ -20,7 +19,6 @@ Lambda supports multiple languages through the use of runtimes. You can choose a
 - Java 11: `java11`
 - Java 8: `java8.al2`
 - .NET 8: `dotnet8`
-- .NET 7: `dotnet7`
 - .NET 6: `dotnet6`
 - Ruby 3.3: `ruby3.3`
 - Ruby 3.2: `ruby3.2`

--- a/src/Clients/CloudWatchLogsClient.php
+++ b/src/Clients/CloudWatchLogsClient.php
@@ -7,6 +7,4 @@ namespace Hammerstone\Sidecar\Clients;
 
 use Aws\CloudWatchLogs\CloudWatchLogsClient as BaseClient;
 
-class CloudWatchLogsClient extends BaseClient
-{
-}
+class CloudWatchLogsClient extends BaseClient {}

--- a/src/Clients/S3Client.php
+++ b/src/Clients/S3Client.php
@@ -4,6 +4,4 @@ namespace Hammerstone\Sidecar\Clients;
 
 use Aws\S3\S3Client as BaseClient;
 
-class S3Client extends BaseClient
-{
-}
+class S3Client extends BaseClient {}

--- a/src/Exceptions/ConfigurationException.php
+++ b/src/Exceptions/ConfigurationException.php
@@ -5,6 +5,4 @@
 
 namespace Hammerstone\Sidecar\Exceptions;
 
-class ConfigurationException extends SidecarException
-{
-}
+class ConfigurationException extends SidecarException {}

--- a/src/Exceptions/LambdaExecutionException.php
+++ b/src/Exceptions/LambdaExecutionException.php
@@ -5,6 +5,4 @@
 
 namespace Hammerstone\Sidecar\Exceptions;
 
-class LambdaExecutionException extends SidecarException
-{
-}
+class LambdaExecutionException extends SidecarException {}

--- a/src/Exceptions/SidecarException.php
+++ b/src/Exceptions/SidecarException.php
@@ -7,6 +7,4 @@ namespace Hammerstone\Sidecar\Exceptions;
 
 use Exception;
 
-class SidecarException extends Exception
-{
-}
+class SidecarException extends Exception {}

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -39,6 +39,7 @@ abstract class Runtime
 
     public const DOT_NET_8 = 'dotnet8';
 
+    /** @deprecated */
     public const DOT_NET_7 = 'dotnet7';
 
     public const DOT_NET_6 = 'dotnet6';

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -8,6 +8,7 @@ abstract class Runtime
 
     public const NODEJS_18 = 'nodejs18.x';
 
+    /** @deprecated */
     public const NODEJS_16 = 'nodejs16.x';
 
     /** @deprecated */

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -22,6 +22,7 @@ abstract class Runtime
 
     public const PYTHON_39 = 'python3.9';
 
+    /** @deprecated */
     public const PYTHON_38 = 'python3.8';
 
     /** @deprecated */


### PR DESCRIPTION
Add deprecated tag to the .NET 7, Node.js 16 and Python 3.8 runtime options.

![image](https://github.com/user-attachments/assets/d00d262e-01a0-4ec4-8d28-5fd395ef6713)


