### PR TITLE
Make the description dependent on the deployment environment

### DIFF
--- a/docs/functions/customization.md
+++ b/docs/functions/customization.md
@@ -231,6 +231,26 @@ You likely won't need to change this, but if you do, *you must include the envir
     }
 ```
 
+### Description
+
+By default, Sidecar will generate a description for your Lambda function based on the deployment environment and the name of your app. 
+
+You likely won't need to customise it, however, you can if you want, although it has no direct impact.
+
+```php
+    class ExampleFunction extends LambdaFunction
+    {
+        public function description()
+        {
+            return sprintf('%s [%s]: Sidecar function `%s`.', ...[
+                config('sidecar.app_name'),
+                Sidecar::getEnvironment(),
+                static::class,
+            ]);
+        }
+    }
+```
+
 ## Tags
 
 A key-value array of strings of tags to be applied to your function, this can be used to organize your functions by owner, project or departement.

--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -160,7 +160,7 @@ abstract class LambdaFunction
     {
         return sprintf('%s [%s]: Sidecar function `%s`.', ...[
             config('sidecar.app_name'),
-            config('app.env'),
+            Sidecar::getEnvironment(),
             static::class,
         ]);
     }


### PR DESCRIPTION
I recently noticed that in my AWS Lambda Console, the descriptions of my Lambda functions deployed by Sidecar didn't have the right description.

For example, I had : `MyAPP [testing]: Sidecar function 'LambdaFunction'` for a function deployed for the production environment.

After investigating, I realised that the function generating this description was based on the current execution environment at the time the deploy command was used, and not on the potential environment defined with --env= in cases where they are different.

If we take the case of a final CI/CD Pipeline where we execute a final set of tests before deploying a potential new version of our Lambda Functions and finally deploying our code (with a vapor command or other script), we end up with a description corresponding to the test environment, even if the command was : `php artisan sidecar deploy --env=production`

To counter this problem :

* Updated `description` function to make it use `Sidecar::getEnvironment()` instead of `config('app.env')`
Allows the right environment to be used every time.

* Modified the documentation to add a reference to possible customization of the description
In addition to the name and prefix already present in the doc


Thank you for this package :rocket: 